### PR TITLE
Fix Legend Dot Squish/Placement  + Refactor Legend.jsx

### DIFF
--- a/src/components/Legend/Legend.jsx
+++ b/src/components/Legend/Legend.jsx
@@ -1,68 +1,30 @@
 import {
-    Grid,
-    Stack,
-    Paper,
-    Typography,
-  } from "@mui/material";
+  Grid,
+  Paper,
+  Typography,
+} from "@mui/material";
+import LegendItem from "./LegendItem";
 
-function Legend(){
-    return (
-        <Paper elevation={8} sx={{ textAlign: "center", height: 2 / 2 }}>
-              <Typography variant="h5">Language Categories</Typography>
+function Legend() {
+  return (
+    <Paper elevation={8} sx={{ textAlign: "center", height: 2 / 2 }}>
+      <Typography variant="h5">Language Categories</Typography>
 
-              <br />
+      <br />
 
-              <Grid container spacing={2} rowSpacing={6} sx={{ pr: 1, pl: 1 }}>
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-asian" />
-                    <Typography>Asian</Typography>
-                  </Stack>
-                </Grid>
-
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-latino" />
-                    <Typography>Latino</Typography>
-                  </Stack>
-                </Grid>
-
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-european" />
-                    <Typography>European</Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-middle-east" />
-                    <Typography>Middle East</Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-sign-language" />
-                    <Typography>Sign Language</Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={4}>
-                  <Stack direction="row">
-                    <div className="lang-native-american" />{" "}
-                    <Typography>Native American</Typography>
-                  </Stack>
-                </Grid>
-                <Grid item xs={4} />
-                <Grid item xs={4}>
-                  <Stack direction="row" spacing={1}>
-                    <div className="lang-varieties-of-english" />
-                    <Typography>
-                      Varieties of <br /> English
-                    </Typography>
-                  </Stack>
-                </Grid>
-              </Grid>
-            </Paper>
-    )
+      <Grid container spacing={2} rowSpacing={6} sx={{ pr: 1, pl: 1 }}>
+        <LegendItem text="Asian" languageClass="lang-asian" />
+        <LegendItem text="Latino" languageClass="lang-latino" />
+        <LegendItem text="European" languageClass="lang-european" />
+        <LegendItem text="Middle East" languageClass="lang-middle-east" />
+        <LegendItem text="Sign Language" languageClass="lang-sign-language" />
+        <LegendItem text="Native American" languageClass="lang-native-american" />
+        
+          <Grid item xs={4} />
+        <LegendItem text={"Varieties of\nEnglish"} languageClass="lang-varieties-of-english" />
+      </Grid>
+    </Paper>
+  )
 }
 
 export default Legend;

--- a/src/components/Legend/LegendItem.css
+++ b/src/components/Legend/LegendItem.css
@@ -1,0 +1,8 @@
+.legend-dot {
+    margin-right: 1em;
+    margin-bottom: .05em;
+}
+
+.legend-container > * {
+    display: inline-block;
+}

--- a/src/components/Legend/LegendItem.jsx
+++ b/src/components/Legend/LegendItem.jsx
@@ -2,16 +2,18 @@ import {
     Grid,
     Stack,
     Typography,
-  } from "@mui/material";
+} from "@mui/material";
+import './LegendItem.css';
 
 function LegendItem({ text, languageClass }) {
     return (
-    <Grid item xs={4}>
-        <Stack direction="row" spacing={1}>
-            <div className={languageClass} />
-            <Typography>{text}</Typography>
-        </Stack>
-    </Grid>
+        <Grid item xs={6}>
+            <div className="flex-container legend-container">
+                <div className={languageClass + ' legend-dot'} />
+                <div>{text}</div>
+            </div>
+
+        </Grid>
     )
 }
 

--- a/src/components/Legend/LegendItem.jsx
+++ b/src/components/Legend/LegendItem.jsx
@@ -1,0 +1,18 @@
+import {
+    Grid,
+    Stack,
+    Typography,
+  } from "@mui/material";
+
+function LegendItem({ text, languageClass }) {
+    return (
+    <Grid item xs={4}>
+        <Stack direction="row" spacing={1}>
+            <div className={languageClass} />
+            <Typography>{text}</Typography>
+        </Stack>
+    </Grid>
+    )
+}
+
+export default LegendItem;

--- a/src/components/Map/Map.css
+++ b/src/components/Map/Map.css
@@ -1,6 +1,8 @@
 .dot {
     width: 10px;
     height: 10px;
+    min-width: 10px;
+    min-height: 10px;
     border-radius: 50%;
     background-color: blue;
     transform: translate(-50%,-50%);


### PR DESCRIPTION
Fixes #124 

Jack, I'd like you in particular to take a look at this - I had to remove some MUI stuff and replace it with plain css to get the dots to stop squishing and getting weird placements.

They're now better centered, and respond a bit better (though not ideally) to smaller screen sizes) and different browser zooms.